### PR TITLE
Fix macOS CI

### DIFF
--- a/.github/workflows/matlab_ci.yml
+++ b/.github/workflows/matlab_ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-12]
         matlab_version: [R2021a, R2021b, R2022a]
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
The old matlab versions used in CI do not support `macos-latest`, so let's pin `macos-12` (at least until it is supported).